### PR TITLE
docker-machine support for use of volumes

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,0 +1,5 @@
+FROM postgres:12.2-alpine
+
+# Used when no existing database on postgres volume, including first initialization.
+# See: https://github.com/docker-library/docs/blob/master/postgres/README.md#initialization-scripts
+COPY ./init-dbs.sh /docker-entrypoint-initdb.d/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,16 +9,15 @@ volumes:
 
 services:
   db:
-    image: postgres:12.2-alpine
+    build: ./db
     container_name: culturestake-db
     env_file:
       - .env
     volumes:
-      - ./db/init-dbs.sh:/docker-entrypoint-initdb.d/init-dbs.sh
       - data:/var/lib/postgresql/data
 
   nginx:
-    image: nginx:1.19.1-alpine
+    build: ./nginx-proxy
     container_name: culturestake-nginx-proxy
     depends_on:
       - db
@@ -29,10 +28,11 @@ services:
       - conf:/etc/nginx/conf.d
       - html:/usr/share/nginx/html
       - vhost.d:/etc/nginx/vhost.d
-      - ./nginx-proxy/default:/etc/nginx/vhost.d/default
 
   gen:
-    image: jwilder/docker-gen:0.7.0
+    build:
+      context: ./nginx-proxy
+      dockerfile: Dockerfile.docker-gen
     container_name: culturestake-nginx-gen
     depends_on:
       - nginx
@@ -42,5 +42,4 @@ services:
       - html:/usr/share/nginx/html
       - vhost.d:/etc/nginx/vhost.d
       - /var/run/docker.sock:/tmp/docker.sock:ro
-      - ./nginx-proxy/nginx.tmpl:/etc/docker-gen/templates/nginx.tmpl:ro
     command: -notify-sighup culturestake-nginx-proxy -wait 5s:30s /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf

--- a/nginx-proxy/Dockerfile
+++ b/nginx-proxy/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:1.19.1-alpine
+
+# See: https://github.com/docker-library/docs/blob/master/postgres/README.md#initialization-scripts
+COPY ./default /etc/nginx/vhost.d/

--- a/nginx-proxy/Dockerfile.docker-gen
+++ b/nginx-proxy/Dockerfile.docker-gen
@@ -1,0 +1,4 @@
+FROM jwilder/docker-gen:0.7.0
+
+# See: https://github.com/docker-library/docs/blob/master/postgres/README.md#initialization-scripts
+COPY ./nginx.tmpl /etc/docker-gen/templates/


### PR DESCRIPTION
I use docker-machine to run docker on a DigitalOcean instance, since my local machine has a tough time with some projects with a few containers.

It mostly works fine, and is meant to be a drop-in replacement for local docker on projects. But one thing docker-machine can't handle is local mounts (unnamed). (internally, docker expands the relative path locally like `./foo` to `/Users/patcon/culturestake-provisioning/foo`, and so docker on the remote machine creates and mounts that empty dir on the server. Something about dockers architecture makes this not easily fixable, even though docker-machine is an official tool)

Anyhow, if you felt ok merging this, it means people both with and without powerful workstations can contribute a bit easier. No pressure.

It adds a minimal Dockerfile for containers with those previous types of mounts, now with a COPY. docker-marchine sends the whole docker context to the server, so this works fine.

Further, might be able to use docker-gen as a mulitstage volume, where processed template is copied over, but wasn't clear enough on its operation to do it.